### PR TITLE
Add PHP login example for XAMPP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore environment files
+.env
+
+# Ignore IDE files
+.idea/
+
+# Ignore system files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# adv_doc_mgt_sys
+# Advanced Document Management System
+
+This repository demonstrates a simple login page using PHP and MySQL intended for use with XAMPP on a local machine.
+
+## Prerequisites
+
+- [XAMPP](https://www.apachefriends.org/) installed (includes PHP, MySQL, and Apache).
+- Basic knowledge of how to import a SQL file into MySQL (using phpMyAdmin or the `mysql` command).
+
+## Setup Instructions
+
+1. Clone this repository into your XAMPP `htdocs` folder:
+   ```bash
+   git clone <repo-url> adv_doc_mgt_sys
+   ```
+2. Start Apache and MySQL from the XAMPP control panel.
+3. Create a MySQL database named `docs` and import `database/create_users_table.sql`.
+4. Edit `config.php` if your MySQL credentials differ from the defaults.
+5. Navigate to `http://localhost/adv_doc_mgt_sys/login.html` in your browser to view the login form.
+
+## File Overview
+
+- `login.html` – The login form.
+- `login.php` – Handles login submissions.
+- `config.php` – Database connection details.
+- `database/create_users_table.sql` – SQL script to create a simple `users` table and seed a user.
+
+## Contributing
+
+This repository is a minimal example. Feel free to fork and extend it. Pull requests are welcome.

--- a/config.php
+++ b/config.php
@@ -1,0 +1,15 @@
+<?php
+// Database configuration
+$host = 'localhost';
+$db   = 'docs';
+$user = 'root';
+$pass = '';
+
+// Create a new PDO connection
+try {
+    $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $user, $pass);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+    die('Connection failed: ' . $e->getMessage());
+}
+?>

--- a/database/create_users_table.sql
+++ b/database/create_users_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(50) NOT NULL UNIQUE,
+  password VARCHAR(255) NOT NULL
+);
+
+INSERT INTO users (username, password) VALUES
+  ('admin', SHA2('password', 256));

--- a/login.html
+++ b/login.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <form action="login.php" method="post">
+        <label for="username">Username:</label>
+        <input type="text" id="username" name="username" required><br>
+        <label for="password">Password:</label>
+        <input type="password" id="password" name="password" required><br>
+        <input type="submit" value="Login">
+    </form>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,21 @@
+<?php
+require 'config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    $stmt = $pdo->prepare('SELECT password FROM users WHERE username = ?');
+    $stmt->execute([$username]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($row && hash('sha256', $password) === $row['password']) {
+        echo 'Login successful!';
+    } else {
+        echo 'Invalid username or password';
+    }
+} else {
+    header('Location: login.html');
+    exit();
+}
+?>


### PR DESCRIPTION
## Summary
- add README with setup instructions
- provide `.gitignore`
- create database seed script
- add PHP config for DB connection
- implement simple login form and handler

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685092aa715883259a65bd4d97b19be9